### PR TITLE
Allow any node >= 0.11, npm >= 1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "homepage": "https://github.com/nitram509/macaroons.js",
   "engines": {
-    "node": "0.11.x",
-    "npm": "1.4.x"
+    "node": ">=0.11",
+    "npm": ">=1.4"
   },
   "dependencies": {
     "ecma-nacl": "^2.0.1",


### PR DESCRIPTION
This fixes a warning I get when installing macaroons.js on node@0.12.2 & npm@2.8.4