### PR TITLE
Export MacaroonsConstants

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@
  */
 
 module.exports = {
+  "MacaroonsConstants" : require('./lib/MacaroonsConstants'),
   "MacaroonsBuilder" : require('./lib/MacaroonsBuilder'),
   "MacaroonsVerifier" : require('./lib/MacaroonsVerifier'),
   "MacaroonsSerializer" : require('./lib/MacaroonsSerializer'),


### PR DESCRIPTION
MacaroonsConstants should be exposed as is referenced [here](/nitram509/macaroons.js#choosing-secrets) and in issue #7.